### PR TITLE
Set up development environment (AGENTS.md + Node 16 notes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`hand-off` ("HandOff") is a single Create React App frontend (React 16, `react-scripts` 3.4.1) — a WebRTC/WebTorrent P2P app for chat, audio/video calls, and file sharing. There is no backend in this repo; standard commands live in `package.json` (`start`, `build`, `test`).
+
+### Node version (important)
+- `react-scripts` 3.4.1 (webpack 4) requires **Node 16**. It does not build/run cleanly on the VM's default newer Node.
+- The startup update script installs deps under Node 16 via nvm. In a fresh interactive shell the `node` on `PATH` may still resolve to a newer Node (e.g. `/exec-daemon/node`), so activate Node 16 before running any `npm` command:
+  ```
+  export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 16
+  ```
+  (Node 16 is the nvm `default`; login shells generally pick it up, but activate explicitly to be safe.)
+
+### Run / build / test / lint
+- Dev server: `BROWSER=none npm start` → http://localhost:3000. Under Node 16 no `--openssl-legacy-provider` flag is needed.
+- Build: `npm run build`. ESLint (`react-app` config) runs as part of `start`/`build`; there is no separate lint script.
+- Tests: `react-scripts test` runs Jest. Run non-interactively with `CI=true npm test -- --forceExit --watchAll=false`. `--forceExit` is required because `src/App.test.js` renders the full app, whose WebTorrent/socket.io imports leave open handles that otherwise keep Jest from exiting. Note: this single test is a leftover default CRA test that fails (looks for "learn react" and renders `NavLink` without a Router) — it is a pre-existing test bug, not an environment problem.
+
+### App behavior gotchas (pre-existing, not env issues)
+- The signaling backend is hardcoded to `https://hand-off-server.herokuapp.com/` (now dead / returns 404), so real peer-to-peer connectivity (multi-user chat, calls) will not establish. Sent chat messages still render locally via Redux, so single-client chat is demonstrable.
+- On first load the app shows a native `prompt()` for a username (stored in `localStorage` under `handoff-user`); entering Chat triggers another `prompt()` for the room id.
+- `src/components/Chat.js` reads the user from `localStorage` at module-load time. Clicking Chat on the very first load (before the username is persisted) can throw "Cannot read properties of null (reading 'name')". A full page reload after the name is set resolves it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `hand-off` (a Create React App / React 16 WebRTC + WebTorrent chat/call/file-share app) and documents durable, non-obvious setup notes for future agents.

This PR only adds `AGENTS.md` — no application code is modified. The environment update script (dependency refresh) is configured separately via the Cursor Cloud environment settings.

## What was done

- Installed **Node 16** (via nvm) since `react-scripts` 3.4.1 (webpack 4) does not build/run cleanly on newer Node.
- Installed dependencies with `npm ci`.
- Verified lint (via build's ESLint), tests, build, and the dev server.
- Completed a hello-world task: sent chat messages in the running app and confirmed they render.

## Verification

| Task | Command | Result |
|---|---|---|
| Install | `npm ci` (Node 16) | ✅ 1821 packages installed |
| Lint | ESLint via `npm run build` | ✅ no errors |
| Build | `npm run build` | ✅ Compiled successfully |
| Test | `CI=true npm test -- --forceExit --watchAll=false` | ⚠️ Jest runs; the single leftover default `App.test.js` fails (pre-existing test bug, not env) |
| Run | `BROWSER=none npm start` | ✅ dev server on http://localhost:3000 (HTTP 200) |

## Hello-world demo

Sent chat messages in the General Chat room; they render locally as message bubbles.

[handoff_chat_demo.mp4](https://cursor.com/agents/bc-f3572c06-ba8b-4a06-b2c0-afd2c56a6243/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhandoff_chat_demo.mp4)

[Chat messages sent](https://cursor.com/agents/bc-f3572c06-ba8b-4a06-b2c0-afd2c56a6243/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhandoff_chat_messages.webp)

## Notes (pre-existing, not environment issues)
- The signaling backend is hardcoded to a now-dead Heroku URL, so multi-peer connectivity won't establish; single-client chat still renders locally.
- `App.test.js` is a leftover default CRA test that fails and needs `--forceExit`.

See `AGENTS.md` → `## Cursor Cloud specific instructions` for full details.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3572c06-ba8b-4a06-b2c0-afd2c56a6243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3572c06-ba8b-4a06-b2c0-afd2c56a6243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

