### PR TITLE
Harmonize with hand-off-server v2 + any-size WebRTC file streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Session BFF (this repo's server/)
+PORT=4000
+CLIENT_ORIGIN=http://localhost:5173
+# Must match hand-off-server ROOM_TOKEN_SECRET
+ROOM_TOKEN_SECRET=dev-room-token-secret-change-me
+TOKEN_TTL_SECONDS=900
+SIGNALING_URL=http://localhost:8989
+
+# Vite client (optional overrides — leave unset to use same-origin proxies)
+# VITE_API_URL=
+# VITE_SIGNALING_URL=http://localhost:8989

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,12 @@ HandOff is an npm-workspaces monorepo for a peer-to-peer chat / audio-video call
 
 ### Services
 - `@hand-off/client` (`client/`) — React 18 + TypeScript + Vite dev server on **:5173**.
-- `@hand-off/server` (`server/`) — Node + Express + Socket.IO signaling server on **:4000**.
+- `@hand-off/server` (`server/`) — Express session BFF on **:4000** (mints room JWTs; no Socket.IO).
+- `hand-off-server` (sibling repo) — authenticated signaling on **:8989**.
 
-Run both together from the repo root with `npm run dev` (uses `concurrently`).
-`npm run dev:server` / `npm run dev:client` run them individually. Build/lint/test
-are `npm run build`, `npm run lint`, `npm test` (see `README.md`).
+Run BFF + client with `npm run dev`. When `../hand-off-server` exists,
+`npm run dev:all` also starts signaling. Build/lint/test are `npm run build`,
+`npm run lint`, `npm test` (see `README.md`).
 
 ### Node version
 - Requires Node 18+ (developed on Node 22). The VM's default `node` (Node 22) is
@@ -20,18 +21,20 @@ are `npm run build`, `npm run lint`, `npm test` (see `README.md`).
   `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22`.
 
 ### Non-obvious gotchas
-- **Dev connectivity:** the client talks to the signaling server via a Vite proxy
-  for `/socket.io` (see `client/vite.config.ts`), so it connects same-origin with
-  a plain `io()` — no CORS config needed in dev. `VITE_SERVER_URL` can override the
-  target if you ever run the client against a remote server.
+- **Dev connectivity:** Vite proxies `/api` → BFF `:4000` and `/socket.io` →
+  signaling `:8989` (see `client/vite.config.ts`). The client uses plain
+  `io()` / `fetch('/api/session')` same-origin unless `VITE_*` overrides are set.
+- **Shared JWT secret:** BFF and `hand-off-server` must use the same
+  `ROOM_TOKEN_SECRET` (dev default `dev-room-token-secret-change-me`).
+- **One peer link:** `hand-off-server` allows one ringing/active call per user.
+  The client auto-links to a single peer for the data channel (chat/files/calls).
 - **Two participants needed:** chat, calls, and file transfer only do something
-  interesting with ≥2 peers in the same room. Open a second browser tab (or share
-  the room name) to test. File sharing is disabled until a peer is present (data
-  channels must be open).
-- **WebRTC mesh:** peer connections use the "perfect negotiation" pattern in
-  `client/src/lib/rtc.ts`; politeness is decided by comparing socket ids, and the
-  impolite peer opens the data channel (which triggers the first offer). Media
-  tracks added/removed during a call renegotiate through the same path.
+  interesting with a linked peer. Open a second browser tab (or share the room
+  name) to test.
+- **WebRTC:** initial `call:invite`/`call:accept` establish the PC + data channel
+  with audio/video sendrecv transceivers. Media is added later via `replaceTrack`
+  (no mid-call SDP). File bytes use SCTP backpressure (`bufferedamountlow`) and
+  OPFS on receive when available.
 - **Testing calls in the VM:** there is no real camera/mic. Launch Chrome with
   fake media so `getUserMedia` succeeds and permission is auto-granted:
   `--use-fake-device-for-media-stream --use-fake-ui-for-media-stream --autoplay-policy=no-user-gesture-required`.

--- a/README.md
+++ b/README.md
@@ -4,38 +4,51 @@
 
 HandOff lets people in a shared room message each other, jump on a live
 audio/video call, and send files that stream **directly between browsers** over
-WebRTC. A lightweight signaling server handles presence, chat relay, and the
-WebRTC handshake; media and files never touch the server.
+WebRTC. Signaling (presence + call/ICE) is handled by
+[`hand-off-server`](https://github.com/gravy17/hand-off-server); media, chat, and
+file bytes never touch the server.
 
 Live demo (legacy build): https://hand-off.netlify.app/
 
 ## Architecture
 
-This is an npm-workspaces monorepo:
+This is an npm-workspaces monorepo that pairs with the external signaling server:
 
 | Package | Path | Stack | Responsibility |
 | --- | --- | --- | --- |
-| `@hand-off/client` | `client/` | React 18 · TypeScript · Vite · Zustand · React Router 6 | UI + WebRTC mesh + data-channel file transfer |
-| `@hand-off/server` | `server/` | Node · Express · Socket.IO 4 | Rooms, presence, chat relay, WebRTC signaling relay |
+| `@hand-off/client` | `client/` | React 18 · TypeScript · Vite · Zustand · React Router 6 | UI + WebRTC + data-channel chat/files |
+| `@hand-off/server` | `server/` | Node · Express | Session BFF — mints room JWTs; serves `client/dist` |
+| `hand-off-server` | separate repo | Socket.IO 4 · JWT rooms | Presence + 1:1 call/ICE signaling |
 
-- **Chat & presence** are relayed through Socket.IO (reliable, instant).
-- **Audio/video calls** use native `RTCPeerConnection` in a full mesh with the
-  [perfect-negotiation](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation)
-  pattern, so either peer can (re)negotiate when tracks are added/removed.
-- **File sharing** streams chunks over a reliable `RTCDataChannel` per peer,
-  with backpressure handling and progress reporting.
+- **Presence & call signaling** go through `hand-off-server` (JWT auth, `call:*` / `signal:ice`).
+- **Chat & file bytes** travel only on a reliable `RTCDataChannel` (no Socket.IO data plane).
+- **Audio/video** uses `replaceTrack` on pre-created transceivers so media can start after the
+  data link without mid-call SDP renegotiation (the signaling API has no mid-call SDP path).
 
-In development the Vite dev server proxies `/socket.io` to the signaling server,
-so the client connects same-origin (no CORS). In production the server can serve
-the built client from `client/dist`.
+In development the Vite dev server proxies `/api` → session BFF and `/socket.io` →
+`hand-off-server`, so the browser stays same-origin.
 
 ## Getting started
 
-Requires **Node.js 18+** (developed on Node 22).
+Requires **Node.js 18+** (developed on Node 22), plus a running
+[`hand-off-server`](https://github.com/gravy17/hand-off-server) instance.
 
 ```bash
-npm install        # installs both workspaces
-npm run dev        # starts the signaling server (:4000) and Vite client (:5173)
+# terminal A — signaling (from the hand-off-server checkout)
+export ROOM_TOKEN_SECRET='dev-room-token-secret-change-me'
+export ALLOWED_ORIGINS='http://localhost:5173'
+npm start   # :8989
+
+# terminal B — this repo
+cp .env.example .env   # optional; defaults match the secret above
+npm install
+npm run dev            # BFF :4000 + Vite :5173
+```
+
+If both repos are siblings (`../hand-off-server`), you can start everything with:
+
+```bash
+npm run dev:all
 ```
 
 Open http://localhost:5173, pick a display name and room, then open a second tab
@@ -45,11 +58,21 @@ Open http://localhost:5173, pick a display name and room, then open a second tab
 
 | Command | What it does |
 | --- | --- |
-| `npm run dev` | Run server + client together (hot reload) |
+| `npm run dev` | Run session BFF + Vite client |
+| `npm run dev:all` | Also start sibling `hand-off-server` |
 | `npm run build` | Type-check and build the client to `client/dist` |
-| `npm start` | Run the signaling server (serves `client/dist` if built) |
+| `npm start` | Run the session BFF (serves `client/dist` if built) |
 | `npm run lint` | ESLint over the client |
 | `npm test` | Vitest unit tests |
+
+## Environment
+
+| Variable | Where | Purpose |
+| --- | --- | --- |
+| `ROOM_TOKEN_SECRET` | BFF + hand-off-server | Shared HS256 secret for room JWTs |
+| `SIGNALING_URL` | BFF | Advertised signaling base URL in `/api/session` |
+| `VITE_SIGNALING_URL` | client build | Absolute Socket.IO URL (production) |
+| `VITE_API_URL` | client build | Absolute BFF URL when not same-origin |
 
 ## License
 

--- a/client/src/components/CallStage.tsx
+++ b/client/src/components/CallStage.tsx
@@ -15,14 +15,21 @@ export function CallStage() {
   const camEnabled = useStore((s) => s.camEnabled);
   const self = useStore((s) => s.self);
   const peerName = useStore((s) => s.peerName);
+  const linkedPeers = useStore((s) => s.linkedPeers);
   const [error, setError] = useState<string | null>(null);
+  const hasLink = Object.values(linkedPeers).some(Boolean);
 
   async function start(withVideo: boolean) {
     setError(null);
     try {
       await session.startCall(withVideo);
-    } catch {
-      setError('Could not access your microphone/camera. Check permissions and devices.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '';
+      setError(
+        message && !/permission|NotAllowed|NotFound|devices/i.test(message)
+          ? message
+          : 'Could not access your microphone/camera. Check permissions and devices.',
+      );
     }
   }
 
@@ -31,12 +38,16 @@ export function CallStage() {
       <div className="callstage callstage--idle">
         <div className="callstage__cta">
           <h3>Start a live call</h3>
-          <p>Publish your mic and camera to everyone in the room.</p>
+          <p>
+            {hasLink
+              ? 'Publish your mic and camera to your linked peer over WebRTC.'
+              : 'Waiting for a peer data link before a call can start…'}
+          </p>
           <div className="callstage__buttons">
-            <button className="btn btn--primary" onClick={() => start(true)}>
+            <button className="btn btn--primary" onClick={() => start(true)} disabled={!hasLink}>
               <VideoIcon /> Video call
             </button>
-            <button className="btn btn--ghost" onClick={() => start(false)}>
+            <button className="btn btn--ghost" onClick={() => start(false)} disabled={!hasLink}>
               <PhoneIcon /> Audio only
             </button>
           </div>

--- a/client/src/components/ChatPanel.tsx
+++ b/client/src/components/ChatPanel.tsx
@@ -10,8 +10,10 @@ function formatTime(ts: number) {
 
 export function ChatPanel() {
   const messages = useStore((s) => s.messages);
+  const linkedPeers = useStore((s) => s.linkedPeers);
   const [draft, setDraft] = useState('');
   const endRef = useRef<HTMLDivElement>(null);
+  const hasLink = Object.values(linkedPeers).some(Boolean);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -29,7 +31,11 @@ export function ChatPanel() {
     <div className="chat">
       <div className="chat__messages">
         {messages.length === 0 && (
-          <p className="chat__empty">No messages yet. Say hello 👋</p>
+          <p className="chat__empty">
+            {hasLink
+              ? 'No messages yet. Say hello — chat is peer-to-peer over WebRTC.'
+              : 'Waiting for a peer data link… chat will flow directly between browsers.'}
+          </p>
         )}
         {messages.map((m) => (
           <div key={m.id} className={`bubble ${m.mine ? 'bubble--mine' : ''}`}>

--- a/client/src/components/FilePanel.tsx
+++ b/client/src/components/FilePanel.tsx
@@ -7,7 +7,7 @@ import { DownloadIcon, PaperclipIcon } from './icons';
 
 export function FilePanel() {
   const files = useStore((s) => s.files);
-  const peers = useStore((s) => s.peers);
+  const linkedPeers = useStore((s) => s.linkedPeers);
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,7 +23,7 @@ export function FilePanel() {
     }
   }
 
-  const canShare = peers.length > 0;
+  const canShare = Object.values(linkedPeers).some(Boolean);
 
   return (
     <div className="files">
@@ -32,7 +32,7 @@ export function FilePanel() {
           className="btn btn--primary"
           onClick={() => inputRef.current?.click()}
           disabled={!canShare}
-          title={canShare ? 'Send a file to everyone in the room' : 'Waiting for peers to join'}
+          title={canShare ? 'Send a file over the WebRTC data channel' : 'Waiting for a peer data link'}
         >
           <PaperclipIcon /> Send a file
         </button>
@@ -43,7 +43,7 @@ export function FilePanel() {
           hidden
           onChange={(e) => onPick(e.target.files)}
         />
-        {!canShare && <span className="files__note">Waiting for a peer to join…</span>}
+        {!canShare && <span className="files__note">Waiting for a peer data link…</span>}
       </div>
 
       {error && <p className="files__error">{error}</p>}
@@ -56,6 +56,7 @@ export function FilePanel() {
               <span className="filecard__name" title={f.name}>{f.name}</span>
               <span className="filecard__meta">
                 {formatBytes(f.size)} · {f.direction === 'outgoing' ? 'sent' : `from ${f.fromName}`}
+                {f.error ? ` · ${f.error}` : ''}
               </span>
               {!f.done && (
                 <div className="progress">
@@ -69,8 +70,8 @@ export function FilePanel() {
               </a>
             )}
             {f.direction === 'outgoing' && (
-              <span className={`badge ${f.done ? 'badge--ok' : ''}`}>
-                {f.done ? 'Sent' : `${Math.round(f.progress * 100)}%`}
+              <span className={`badge ${f.done && !f.error ? 'badge--ok' : ''}`}>
+                {f.error ? 'Failed' : f.done ? 'Sent' : `${Math.round(f.progress * 100)}%`}
               </span>
             )}
           </li>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,78 @@
+export interface SessionResponse {
+  token: string;
+  userId: string;
+  username: string;
+  roomId: string;
+  expiresIn: number;
+  signalingUrl?: string;
+}
+
+export interface TurnCredentials {
+  urls: string | string[];
+  username: string;
+  credential: string;
+  ttl?: number;
+}
+
+function apiBase(): string {
+  // Same-origin in dev (Vite proxies /api). Override only when the BFF is remote.
+  return import.meta.env.VITE_API_URL || '';
+}
+
+function signalingBase(): string {
+  return import.meta.env.VITE_SIGNALING_URL || import.meta.env.VITE_SERVER_URL || '';
+}
+
+export async function mintSession(roomId: string, username: string, userId: string): Promise<SessionResponse> {
+  const res = await fetch(`${apiBase()}/api/session`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ roomId, username, userId }),
+  });
+
+  if (!res.ok) {
+    let message = 'Could not create a room session.';
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(message);
+  }
+
+  return res.json() as Promise<SessionResponse>;
+}
+
+/** Best-effort TURN credential fetch from hand-off-server (optional). */
+export async function fetchTurnCredentials(token: string): Promise<RTCIceServer[] | null> {
+  const base = signalingBase();
+  if (!base) return null;
+
+  try {
+    const res = await fetch(`${base}/v1/turn/credentials`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as TurnCredentials;
+    return [
+      {
+        urls: body.urls,
+        username: body.username,
+        credential: body.credential,
+      },
+    ];
+  } catch {
+    return null;
+  }
+}
+
+export function resolveSignalingUrl(session?: SessionResponse): string | undefined {
+  return (
+    import.meta.env.VITE_SIGNALING_URL ||
+    import.meta.env.VITE_SERVER_URL ||
+    session?.signalingUrl ||
+    undefined
+  );
+}

--- a/client/src/lib/fileTransfer.test.ts
+++ b/client/src/lib/fileTransfer.test.ts
@@ -52,3 +52,20 @@ describe('Reassembler', () => {
     expect(r.progress).toBe(1);
   });
 });
+
+describe('StreamingReassembler (memory fallback)', () => {
+  it('finalizes a blob after async pushes', async () => {
+    const { StreamingReassembler } = await import('./fileTransfer');
+    const r = await StreamingReassembler.create({
+      id: 'stream-1',
+      name: 'note.txt',
+      size: 5,
+      mime: 'text/plain',
+    });
+    await r.push(new TextEncoder().encode('hello').buffer);
+    expect(r.progress).toBe(1);
+    const blob = await r.finalize();
+    expect(blob.size).toBe(5);
+    expect(await blob.text()).toBe('hello');
+  });
+});

--- a/client/src/lib/fileTransfer.ts
+++ b/client/src/lib/fileTransfer.ts
@@ -1,11 +1,14 @@
 import type { RTCManager } from './rtc';
-import type { DataChannelControl } from './types';
+import type { DataChannelMessage } from './types';
 
 /** Chunk size for data-channel file transfer (64 KiB is well within SCTP limits). */
 export const CHUNK_SIZE = 64 * 1024;
 
 /** Pause sending when a channel's send buffer grows beyond this many bytes. */
-const BUFFER_HIGH_WATERMARK = 4 * 1024 * 1024;
+export const BUFFER_HIGH_WATERMARK = 1 * 1024 * 1024;
+
+/** Resume when the buffer drains to this many bytes. */
+export const BUFFER_LOW_WATERMARK = 256 * 1024;
 
 export function makeFileId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
@@ -24,7 +27,192 @@ export function formatBytes(bytes: number): string {
   return `${value.toFixed(value >= 10 || Number.isInteger(value) ? 0 : 1)} ${units[unit]}`;
 }
 
-/** Reassembles data-channel chunks for a single incoming file. */
+function waitForBufferedAmountLow(dc: RTCDataChannel, low: number): Promise<void> {
+  if (dc.readyState !== 'open') {
+    return Promise.reject(new Error('Data channel closed during transfer'));
+  }
+  if (dc.bufferedAmount <= low) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    const onLow = () => {
+      cleanup();
+      resolve();
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error('Data channel closed during transfer'));
+    };
+    const cleanup = () => {
+      dc.removeEventListener('bufferedamountlow', onLow);
+      dc.removeEventListener('close', onClose);
+    };
+    dc.bufferedAmountLowThreshold = low;
+    dc.addEventListener('bufferedamountlow', onLow);
+    dc.addEventListener('close', onClose);
+  });
+}
+
+async function waitForBackpressure(manager: RTCManager): Promise<void> {
+  while (manager.maxBufferedAmount() > BUFFER_HIGH_WATERMARK) {
+    const channels = manager.openChannels();
+    if (channels.length === 0) {
+      throw new Error('Data channel closed during transfer');
+    }
+    await Promise.race(channels.map((dc) => waitForBufferedAmountLow(dc, BUFFER_LOW_WATERMARK)));
+  }
+}
+
+/**
+ * Stream a file to all linked peers over WebRTC data channels.
+ *
+ * Only one `CHUNK_SIZE` window is materialized at a time (`File.slice`), so
+ * senders can handle files of any size without loading them into memory.
+ * Backpressure uses `bufferedamountlow` (no Socket.IO involvement).
+ */
+export async function sendFile(
+  manager: RTCManager,
+  fileId: string,
+  file: File,
+  onProgress: (progress: number) => void,
+): Promise<void> {
+  if (!manager.hasOpenChannels()) {
+    throw new Error('No connected peers yet — wait for someone to join the room.');
+  }
+
+  const meta: DataChannelMessage = {
+    kind: 'file-meta',
+    id: fileId,
+    name: file.name,
+    size: file.size,
+    mime: file.type,
+  };
+  manager.broadcast(JSON.stringify(meta));
+
+  let offset = 0;
+
+  try {
+    while (offset < file.size) {
+      await waitForBackpressure(manager);
+      const blob = file.slice(offset, offset + CHUNK_SIZE);
+      const buffer = await blob.arrayBuffer();
+      manager.broadcast(buffer);
+      offset += buffer.byteLength;
+      onProgress(file.size ? offset / file.size : 1);
+    }
+
+    const end: DataChannelMessage = { kind: 'file-end', id: fileId };
+    manager.broadcast(JSON.stringify(end));
+    onProgress(1);
+  } catch (err) {
+    const abort: DataChannelMessage = {
+      kind: 'file-abort',
+      id: fileId,
+      reason: err instanceof Error ? err.message : 'transfer failed',
+    };
+    try {
+      manager.broadcast(JSON.stringify(abort));
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+/**
+ * Streams an incoming file to disk when possible.
+ *
+ * Uses the Origin Private File System so multi‑GB transfers do not retain every
+ * chunk in RAM. Falls back to in-memory chunk accumulation when OPFS is missing.
+ */
+export class StreamingReassembler {
+  received = 0;
+  private chunks: ArrayBuffer[] = [];
+  private opfsHandle: FileSystemFileHandle | null = null;
+  private writable: FileSystemWritableFileStream | null = null;
+  private closed = false;
+
+  constructor(public readonly meta: { id: string; name: string; size: number; mime: string }) {}
+
+  static async create(meta: {
+    id: string;
+    name: string;
+    size: number;
+    mime: string;
+  }): Promise<StreamingReassembler> {
+    const r = new StreamingReassembler(meta);
+    await r.init();
+    return r;
+  }
+
+  private async init(): Promise<void> {
+    try {
+      if (!navigator.storage?.getDirectory) return;
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle('handoff-transfers', { create: true });
+      this.opfsHandle = await dir.getFileHandle(this.meta.id, { create: true });
+      this.writable = await this.opfsHandle.createWritable();
+    } catch {
+      this.opfsHandle = null;
+      this.writable = null;
+    }
+  }
+
+  async push(chunk: ArrayBuffer): Promise<void> {
+    if (this.closed) return;
+    this.received += chunk.byteLength;
+    if (this.writable) {
+      await this.writable.write(chunk);
+      return;
+    }
+    this.chunks.push(chunk);
+  }
+
+  get progress(): number {
+    if (this.meta.size <= 0) return 1;
+    return Math.min(1, this.received / this.meta.size);
+  }
+
+  async abort(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      await this.writable?.abort();
+    } catch {
+      /* ignore */
+    }
+    this.writable = null;
+    this.chunks = [];
+    if (this.opfsHandle) {
+      try {
+        const root = await navigator.storage.getDirectory();
+        const dir = await root.getDirectoryHandle('handoff-transfers');
+        await dir.removeEntry(this.meta.id);
+      } catch {
+        /* ignore */
+      }
+      this.opfsHandle = null;
+    }
+  }
+
+  async finalize(): Promise<Blob> {
+    if (this.closed) throw new Error('transfer already closed');
+    this.closed = true;
+
+    if (this.writable && this.opfsHandle) {
+      await this.writable.close();
+      this.writable = null;
+      const file = await this.opfsHandle.getFile();
+      return new Blob([file], { type: this.meta.mime || file.type || 'application/octet-stream' });
+    }
+
+    return new Blob(this.chunks, { type: this.meta.mime || 'application/octet-stream' });
+  }
+}
+
+/**
+ * Synchronous in-memory reassembler for unit tests and tiny payloads.
+ * Production receive path uses {@link StreamingReassembler}.
+ */
 export class Reassembler {
   private chunks: ArrayBuffer[] = [];
   received = 0;
@@ -44,42 +232,4 @@ export class Reassembler {
   toBlob(): Blob {
     return new Blob(this.chunks, { type: this.meta.mime || 'application/octet-stream' });
   }
-}
-
-const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-/**
- * Stream a file to all connected peers over their data channels, respecting
- * backpressure. Calls `onProgress` (0..1) as it goes.
- */
-export async function sendFile(
-  manager: RTCManager,
-  fileId: string,
-  file: File,
-  onProgress: (progress: number) => void,
-): Promise<void> {
-  const meta: DataChannelControl = {
-    kind: 'file-meta',
-    id: fileId,
-    name: file.name,
-    size: file.size,
-    mime: file.type,
-  };
-  manager.broadcast(JSON.stringify(meta));
-
-  let offset = 0;
-  while (offset < file.size) {
-    while (manager.maxBufferedAmount() > BUFFER_HIGH_WATERMARK) {
-      await delay(20);
-    }
-    const slice = file.slice(offset, offset + CHUNK_SIZE);
-    const buffer = await slice.arrayBuffer();
-    manager.broadcast(buffer);
-    offset += buffer.byteLength;
-    onProgress(file.size ? offset / file.size : 1);
-  }
-
-  const end: DataChannelControl = { kind: 'file-end', id: fileId };
-  manager.broadcast(JSON.stringify(end));
-  onProgress(1);
 }

--- a/client/src/lib/identity.ts
+++ b/client/src/lib/identity.ts
@@ -1,0 +1,17 @@
+const USER_ID_KEY = 'handoff:userId';
+
+/** Stable per-browser user id used as the JWT `sub` / signaling `userId`. */
+export function getOrCreateUserId(): string {
+  try {
+    const existing = localStorage.getItem(USER_ID_KEY);
+    if (existing) return existing;
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `user-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    localStorage.setItem(USER_ID_KEY, id);
+    return id;
+  } catch {
+    return `user-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}

--- a/client/src/lib/rtc.ts
+++ b/client/src/lib/rtc.ts
@@ -1,69 +1,148 @@
 /**
- * A small WebRTC mesh manager.
+ * WebRTC peer manager for hand-off-server v2.
  *
- * It maintains one `RTCPeerConnection` per remote peer in the room, using the
- * "perfect negotiation" pattern so either side can (re)negotiate safely — e.g.
- * when media tracks are added/removed for a call. Each connection also carries
- * a reliable `RTCDataChannel` used for peer-to-peer file transfer.
- *
- * Signaling (SDP + ICE) is relayed through the caller-provided `sendSignal`,
- * which in this app is a socket.io message routed to a specific peer.
+ * Signaling uses the server call state machine (invite → accept + ICE).
+ * Each linked peer gets one RTCPeerConnection with:
+ *   - a reliable data channel (chat + file bytes; never Socket.IO)
+ *   - audio/video sendrecv transceivers so media can be added later via
+ *     replaceTrack without SDP renegotiation (the server has no mid-call SDP path)
  */
 
-const STUN_SERVERS: RTCIceServer[] = [
+const DEFAULT_STUN: RTCIceServer[] = [
   { urls: ['stun:stun.l.google.com:19302', 'stun:stun1.l.google.com:19302'] },
 ];
 
 const DATA_CHANNEL_LABEL = 'handoff';
 
+function descriptionInit(desc: RTCSessionDescription | null): RTCSessionDescriptionInit {
+  if (!desc) throw new Error('missing local description');
+  return { type: desc.type, sdp: desc.sdp };
+}
+
+function candidateInit(candidate: RTCIceCandidate): RTCIceCandidateInit {
+  return candidate.toJSON();
+}
+
+export interface RTCSignaling {
+  invite: (toUserId: string, signal: RTCSessionDescriptionInit) => void;
+  accept: (toUserId: string, signal: RTCSessionDescriptionInit) => void;
+  reject: (toUserId: string) => void;
+  end: (toUserId: string) => void;
+  ice: (toUserId: string, candidate: RTCIceCandidateInit) => void;
+}
+
 export interface RTCManagerCallbacks {
   selfId: string;
-  sendSignal: (to: string, data: unknown) => void;
+  signaling: RTCSignaling;
+  iceServers?: RTCIceServer[];
   onRemoteStream: (peerId: string, stream: MediaStream) => void;
   onRemoteStreamEnded: (peerId: string) => void;
   onData: (peerId: string, data: string | ArrayBuffer) => void;
   onDataChannelOpen?: (peerId: string) => void;
+  onDataChannelClose?: (peerId: string) => void;
+  onPeerConnectionState?: (peerId: string, state: RTCPeerConnectionState) => void;
 }
 
 interface PeerState {
   pc: RTCPeerConnection;
   dc: RTCDataChannel | null;
-  makingOffer: boolean;
-  ignoreOffer: boolean;
-  polite: boolean;
+  /** True when we sent call:invite for this peer. */
+  isInitiator: boolean;
+  /** Remote description applied (offer or answer). */
+  remoteSet: boolean;
+  audioSender: RTCRtpSender | null;
+  videoSender: RTCRtpSender | null;
 }
 
 export class RTCManager {
   private peers = new Map<string, PeerState>();
   private localStream: MediaStream | null = null;
+  private iceServers: RTCIceServer[];
 
-  constructor(private cb: RTCManagerCallbacks) {}
+  constructor(private cb: RTCManagerCallbacks) {
+    this.iceServers = cb.iceServers?.length ? cb.iceServers : DEFAULT_STUN;
+  }
 
-  /** Create (or reuse) a connection to a peer and start negotiation if needed. */
-  ensurePeer(peerId: string): PeerState {
+  setIceServers(servers: RTCIceServer[]) {
+    this.iceServers = servers.length ? servers : DEFAULT_STUN;
+  }
+
+  /** Begin a link as the caller: create offer and emit call:invite. */
+  async invitePeer(peerId: string): Promise<void> {
+    if (this.peers.has(peerId)) return;
+
+    const state = this.createPeer(peerId, true);
+    const offer = await state.pc.createOffer();
+    await state.pc.setLocalDescription(offer);
+    this.cb.signaling.invite(peerId, descriptionInit(state.pc.localDescription));
+  }
+
+  /** Handle call:incoming — set remote offer, answer via call:accept. */
+  async handleIncoming(peerId: string, signal: RTCSessionDescriptionInit): Promise<void> {
+    // If we already initiated toward this peer, ignore a colliding invite
+    // (deterministic initiator is decided by userId ordering in Session).
+    if (this.peers.has(peerId) && this.peers.get(peerId)!.isInitiator) {
+      this.cb.signaling.reject(peerId);
+      return;
+    }
+
+    const state = this.peers.get(peerId) ?? this.createPeer(peerId, false);
+    await state.pc.setRemoteDescription(signal);
+    state.remoteSet = true;
+    // Offer m-lines create the answerer's transceivers — capture senders now.
+    this.captureSenders(state);
+    this.publishLocalTo(state);
+
+    const answer = await state.pc.createAnswer();
+    await state.pc.setLocalDescription(answer);
+    this.cb.signaling.accept(peerId, descriptionInit(state.pc.localDescription));
+  }
+
+  /** Handle call:accepted — apply remote answer. */
+  async handleAccepted(peerId: string, signal: RTCSessionDescriptionInit): Promise<void> {
+    const state = this.peers.get(peerId);
+    if (!state) return;
+    await state.pc.setRemoteDescription(signal);
+    state.remoteSet = true;
+  }
+
+  async handleIce(peerId: string, candidate: RTCIceCandidateInit): Promise<void> {
+    const state = this.peers.get(peerId) ?? this.createPeer(peerId, false);
+    try {
+      await state.pc.addIceCandidate(candidate);
+    } catch (err) {
+      // Candidates can race ahead of setRemoteDescription; ignore transient failures.
+      if (!state.remoteSet) return;
+      console.error('[rtc] addIceCandidate failed', err);
+    }
+  }
+
+  private createPeer(peerId: string, isInitiator: boolean): PeerState {
     const existing = this.peers.get(peerId);
     if (existing) return existing;
 
-    const pc = new RTCPeerConnection({ iceServers: STUN_SERVERS });
-    // The peer with the lexicographically smaller id is the "polite" one.
-    const polite = this.cb.selfId < peerId;
-    const state: PeerState = { pc, dc: null, makingOffer: false, ignoreOffer: false, polite };
+    const pc = new RTCPeerConnection({ iceServers: this.iceServers });
+    const state: PeerState = {
+      pc,
+      dc: null,
+      isInitiator,
+      remoteSet: false,
+      audioSender: null,
+      videoSender: null,
+    };
     this.peers.set(peerId, state);
 
-    pc.onnegotiationneeded = async () => {
-      try {
-        state.makingOffer = true;
-        await pc.setLocalDescription();
-        this.cb.sendSignal(peerId, { description: pc.localDescription });
-      } catch (err) {
-        console.error('[rtc] negotiation error', err);
-      } finally {
-        state.makingOffer = false;
-      }
-    };
+    // Only the initiator pre-creates sendrecv transceivers (so media can be
+    // swapped in later via replaceTrack). The answerer adopts m-lines from the offer.
+    if (isInitiator) {
+      const audio = pc.addTransceiver('audio', { direction: 'sendrecv' });
+      const video = pc.addTransceiver('video', { direction: 'sendrecv' });
+      state.audioSender = audio.sender;
+      state.videoSender = video.sender;
+    }
 
     pc.onicecandidate = ({ candidate }) => {
-      if (candidate) this.cb.sendSignal(peerId, { candidate });
+      if (candidate) this.cb.signaling.ice(peerId, candidateInit(candidate));
     };
 
     pc.ontrack = (event) => {
@@ -82,122 +161,149 @@ export class RTCManager {
     };
 
     pc.onconnectionstatechange = () => {
+      this.cb.onPeerConnectionState?.(peerId, pc.connectionState);
       if (pc.connectionState === 'failed') {
         pc.restartIce();
       }
     };
 
-    // The impolite peer opens the data channel; this triggers the initial
-    // offer via `onnegotiationneeded` and avoids both sides opening one.
-    if (!polite) {
+    if (isInitiator) {
       const dc = pc.createDataChannel(DATA_CHANNEL_LABEL, { ordered: true });
       this.attachDataChannel(peerId, state, dc);
     }
 
-    // If a call is already in progress, publish our media to the new peer.
-    if (this.localStream) {
-      for (const track of this.localStream.getTracks()) {
-        pc.addTrack(track, this.localStream);
-      }
-    }
-
+    this.publishLocalTo(state);
     return state;
   }
 
   private attachDataChannel(peerId: string, state: PeerState, dc: RTCDataChannel) {
     dc.binaryType = 'arraybuffer';
+    dc.bufferedAmountLowThreshold = 256 * 1024;
     state.dc = dc;
     dc.onopen = () => this.cb.onDataChannelOpen?.(peerId);
+    dc.onclose = () => this.cb.onDataChannelClose?.(peerId);
     dc.onmessage = (event) => this.cb.onData(peerId, event.data);
   }
 
-  async handleSignal(from: string, data: { description?: RTCSessionDescriptionInit; candidate?: RTCIceCandidateInit }) {
-    const state = this.ensurePeer(from);
-    const { pc } = state;
-
-    try {
-      if (data.description) {
-        const desc = data.description;
-        const offerCollision =
-          desc.type === 'offer' && (state.makingOffer || pc.signalingState !== 'stable');
-
-        state.ignoreOffer = !state.polite && offerCollision;
-        if (state.ignoreOffer) return;
-
-        await pc.setRemoteDescription(desc);
-        if (desc.type === 'offer') {
-          await pc.setLocalDescription();
-          this.cb.sendSignal(from, { description: pc.localDescription });
-        }
-      } else if (data.candidate) {
-        try {
-          await pc.addIceCandidate(data.candidate);
-        } catch (err) {
-          if (!state.ignoreOffer) throw err;
-        }
-      }
-    } catch (err) {
-      console.error('[rtc] signal handling error', err);
+  private captureSenders(state: PeerState) {
+    for (const t of state.pc.getTransceivers()) {
+      const kind = t.receiver.track?.kind || t.sender.track?.kind;
+      if (kind === 'audio') state.audioSender = t.sender;
+      if (kind === 'video') state.videoSender = t.sender;
     }
+    // Initiator offers always add audio then video; use that order as fallback.
+    const ts = state.pc.getTransceivers();
+    if (!state.audioSender && ts[0]) state.audioSender = ts[0].sender;
+    if (!state.videoSender && ts[1]) state.videoSender = ts[1].sender;
   }
 
-  /** Send data to every peer with an open data channel. */
+  private publishLocalTo(state: PeerState) {
+    if (!this.localStream) return;
+    if (!state.audioSender || !state.videoSender) this.captureSenders(state);
+    const audio = this.localStream.getAudioTracks()[0] ?? null;
+    const video = this.localStream.getVideoTracks()[0] ?? null;
+    void state.audioSender?.replaceTrack(audio);
+    void state.videoSender?.replaceTrack(video);
+  }
+
+  /** Send to every peer with an open data channel. */
   broadcast(data: string | ArrayBuffer) {
     for (const { dc } of this.peers.values()) {
       if (dc && dc.readyState === 'open') {
-        dc.send(data as ArrayBuffer);
+        if (typeof data === 'string') dc.send(data);
+        else dc.send(data);
       }
     }
   }
 
-  hasOpenChannels(): boolean {
-    for (const { dc } of this.peers.values()) {
-      if (dc && dc.readyState === 'open') return true;
-    }
-    return false;
+  send(peerId: string, data: string | ArrayBuffer): boolean {
+    const dc = this.peers.get(peerId)?.dc;
+    if (!dc || dc.readyState !== 'open') return false;
+    if (typeof data === 'string') dc.send(data);
+    else dc.send(data);
+    return true;
   }
 
-  /** Largest send-buffer backlog across all open data channels (for backpressure). */
+  getDataChannel(peerId: string): RTCDataChannel | null {
+    return this.peers.get(peerId)?.dc ?? null;
+  }
+
+  openChannels(): RTCDataChannel[] {
+    const channels: RTCDataChannel[] = [];
+    for (const { dc } of this.peers.values()) {
+      if (dc && dc.readyState === 'open') channels.push(dc);
+    }
+    return channels;
+  }
+
+  hasOpenChannels(): boolean {
+    return this.openChannels().length > 0;
+  }
+
+  linkedPeerIds(): string[] {
+    return [...this.peers.keys()];
+  }
+
   maxBufferedAmount(): number {
     let max = 0;
-    for (const { dc } of this.peers.values()) {
-      if (dc && dc.readyState === 'open') max = Math.max(max, dc.bufferedAmount);
+    for (const dc of this.openChannels()) {
+      max = Math.max(max, dc.bufferedAmount);
     }
     return max;
   }
 
-  /** Start (or update) publishing local media to every peer. */
-  setLocalStream(stream: MediaStream) {
+  /** Publish (or update) local media via replaceTrack — no SDP renegotiation. */
+  async setLocalStream(stream: MediaStream) {
     this.localStream = stream;
-    for (const { pc } of this.peers.values()) {
-      const existing = new Set(pc.getSenders().map((s) => s.track));
-      for (const track of stream.getTracks()) {
-        if (!existing.has(track)) pc.addTrack(track, stream);
-      }
-    }
+    const audio = stream.getAudioTracks()[0] ?? null;
+    const video = stream.getVideoTracks()[0] ?? null;
+    await Promise.all(
+      [...this.peers.values()].map(async (state) => {
+        await state.audioSender?.replaceTrack(audio);
+        await state.videoSender?.replaceTrack(video);
+      }),
+    );
   }
 
-  /** Stop publishing local media and renegotiate. */
-  stopLocalStream() {
-    for (const { pc } of this.peers.values()) {
-      for (const sender of pc.getSenders()) {
-        if (sender.track) pc.removeTrack(sender);
-      }
-    }
+  async stopLocalStream() {
+    await Promise.all(
+      [...this.peers.values()].map(async (state) => {
+        await state.audioSender?.replaceTrack(null);
+        await state.videoSender?.replaceTrack(null);
+      }),
+    );
     this.localStream?.getTracks().forEach((t) => t.stop());
     this.localStream = null;
+  }
+
+  endPeer(peerId: string, notify = true) {
+    if (notify && this.peers.has(peerId)) {
+      this.cb.signaling.end(peerId);
+    }
+    this.removePeer(peerId);
   }
 
   removePeer(peerId: string) {
     const state = this.peers.get(peerId);
     if (!state) return;
-    state.dc?.close();
-    state.pc.close();
+    try {
+      state.dc?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      state.pc.close();
+    } catch {
+      /* ignore */
+    }
     this.peers.delete(peerId);
   }
 
-  destroy() {
-    for (const id of [...this.peers.keys()]) this.removePeer(id);
+  destroy(notify = false) {
+    for (const id of [...this.peers.keys()]) {
+      if (notify) this.cb.signaling.end(id);
+      this.removePeer(id);
+    }
     this.localStream?.getTracks().forEach((t) => t.stop());
     this.localStream = null;
   }

--- a/client/src/lib/session.ts
+++ b/client/src/lib/session.ts
@@ -1,134 +1,306 @@
 import { io, type Socket } from 'socket.io-client';
 
 import { RTCManager } from './rtc';
-import { Reassembler, makeFileId, sendFile } from './fileTransfer';
+import { StreamingReassembler, makeFileId, sendFile } from './fileTransfer';
+import { mintSession, fetchTurnCredentials, resolveSignalingUrl } from './api';
+import { getOrCreateUserId } from './identity';
 import { useStore } from '../store/useStore';
-import type { ChatMessage, DataChannelControl, Peer, SharedFile } from './types';
-
-interface JoinResponse {
-  error?: string;
-  selfId: string;
-  roomId: string;
-  username: string;
-  peers: Peer[];
-}
-
-interface ServerChatMessage {
-  id: string;
-  senderId: string;
-  username: string;
-  text: string;
-  ts: number;
-}
+import type { ChatMessage, DataChannelMessage, Peer, RoomMember, SharedFile } from './types';
 
 /**
- * Ties together the signaling socket, the WebRTC mesh, and the UI store.
- * A single instance is shared across the app.
+ * Ties together JWT session minting, hand-off-server signaling, the WebRTC
+ * link, and the UI store. A single instance is shared across the app.
+ *
+ * Socket.IO is used only for presence + call/ICE signaling. Chat text and file
+ * bytes travel exclusively on the WebRTC data channel.
  */
 class Session {
   private socket: Socket | null = null;
   private rtc: RTCManager | null = null;
+  private token: string | null = null;
+  private selfId: string | null = null;
   /** Active incoming transfer per peer (data channel is ordered, so one at a time). */
-  private incoming = new Map<string, Reassembler>();
+  private incoming = new Map<string, StreamingReassembler>();
+  /** Peer userIds we have invited or accepted (server call slot occupied). */
+  private linked = new Set<string>();
+  private linking = new Set<string>();
 
   private disposeConnections() {
-    this.rtc?.destroy();
+    this.rtc?.destroy(true);
     this.rtc = null;
     if (this.socket) {
       this.socket.removeAllListeners();
       this.socket.disconnect();
       this.socket = null;
     }
+    this.token = null;
+    this.selfId = null;
     this.incoming.clear();
+    this.linked.clear();
+    this.linking.clear();
   }
 
   connect(username: string, roomId: string): Promise<void> {
-    // Guard against duplicate connects (e.g. StrictMode double-mount).
     this.disposeConnections();
 
     const store = useStore.getState();
     store.setConnecting(true);
     store.setError(null);
 
+    return (async () => {
+      try {
+        const userId = getOrCreateUserId();
+        const session = await mintSession(roomId, username, userId);
+        this.token = session.token;
+        this.selfId = session.userId;
+
+        const signalingUrl = resolveSignalingUrl(session);
+        await this.openSocket(signalingUrl, session.token, session.username, session.roomId);
+      } catch (err) {
+        store.setConnecting(false);
+        store.setError(err instanceof Error ? err.message : 'Failed to join room');
+        this.disposeConnections();
+        throw err;
+      }
+    })();
+  }
+
+  private openSocket(
+    url: string | undefined,
+    token: string,
+    username: string,
+    roomId: string,
+  ): Promise<void> {
+    const store = useStore.getState();
+
     return new Promise((resolve, reject) => {
-      const socket = io(import.meta.env.VITE_SERVER_URL || undefined, {
+      const socket = io(url || undefined, {
+        auth: { token },
+        transports: ['websocket'],
         reconnectionAttempts: 5,
       });
       this.socket = socket;
 
-      socket.on('connect_error', () => {
-        store.setError('Cannot reach the signaling server. Is it running?');
+      let settled = false;
+      const fail = (message: string) => {
+        if (settled) return;
+        settled = true;
+        store.setError(message);
         store.setConnecting(false);
-        reject(new Error('connect_error'));
+        reject(new Error(message));
+      };
+
+      socket.on('connect_error', (err) => {
+        fail(err?.message || 'Cannot reach the signaling server. Is hand-off-server running?');
       });
 
-      socket.on('connect', () => {
-        socket.emit('join', { roomId, username }, (res: JoinResponse) => {
-          if (res?.error) {
-            store.setError(res.error);
-            store.setConnecting(false);
-            socket.disconnect();
-            reject(new Error(res.error));
-            return;
-          }
-          const self: Peer = { id: res.selfId, username: res.username };
-          store.setSession(self, res.roomId);
-          store.setPeers(res.peers);
-          store.setConnected(true);
-          store.setConnecting(false);
+      socket.on('error:client', (payload: { code?: string; message?: string }) => {
+        if (!useStore.getState().connected) {
+          fail(payload?.message || payload?.code || 'Signaling error');
+        } else {
+          console.warn('[session] server error', payload);
+        }
+      });
 
-          this.setupRtc(res.selfId);
-          for (const peer of res.peers) this.rtc?.ensurePeer(peer.id);
+      socket.on('room:joined', async (payload: { roomId: string; self: RoomMember; members: RoomMember[] }) => {
+        const self: Peer = { id: payload.self.userId, username: payload.self.name || username };
+        this.selfId = self.id;
+        store.setSession(self, payload.roomId || roomId);
+        store.setPeers(this.membersToPeers(payload.members, self.id));
+        store.setConnected(true);
+        store.setConnecting(false);
+
+        const turn = this.token ? await fetchTurnCredentials(this.token) : null;
+        this.setupRtc(self.id, turn ?? undefined);
+        this.reconcileLinks(payload.members);
+
+        if (!settled) {
+          settled = true;
           resolve();
-        });
+        }
       });
 
-      socket.on('peer-joined', (peer: Peer) => {
-        useStore.getState().addPeer(peer);
-        this.rtc?.ensurePeer(peer.id);
+      socket.on(
+        'presence:update',
+        (payload: { members: RoomMember[]; reason?: string; userId?: string }) => {
+          const selfId = this.selfId;
+          if (!selfId) return;
+          store.setPeers(this.membersToPeers(payload.members, selfId));
+
+          if (payload.reason === 'leave' && payload.userId) {
+            this.rtc?.removePeer(payload.userId);
+            this.linked.delete(payload.userId);
+            this.linking.delete(payload.userId);
+            void this.incoming.get(payload.userId)?.abort();
+            this.incoming.delete(payload.userId);
+            store.setPeerLinked(payload.userId, false);
+          }
+
+          this.reconcileLinks(payload.members);
+        },
+      );
+
+      socket.on(
+        'call:incoming',
+        (payload: { fromUserId: string; fromName?: string; signal: RTCSessionDescriptionInit }) => {
+          void this.onIncoming(payload.fromUserId, payload.signal);
+        },
+      );
+
+      socket.on(
+        'call:accepted',
+        (payload: { fromUserId: string; signal: RTCSessionDescriptionInit }) => {
+          this.linked.add(payload.fromUserId);
+          this.linking.delete(payload.fromUserId);
+          store.setPeerLinked(payload.fromUserId, true);
+          void this.rtc?.handleAccepted(payload.fromUserId, payload.signal);
+        },
+      );
+
+      socket.on('call:rejected', (payload: { fromUserId: string }) => {
+        this.linking.delete(payload.fromUserId);
+        this.linked.delete(payload.fromUserId);
+        this.rtc?.removePeer(payload.fromUserId);
+        store.setPeerLinked(payload.fromUserId, false);
       });
 
-      socket.on('peer-left', ({ id }: { id: string }) => {
-        useStore.getState().removePeer(id);
-        this.rtc?.removePeer(id);
-        this.incoming.delete(id);
+      socket.on('call:ended', (payload: { fromUserId: string }) => {
+        this.linking.delete(payload.fromUserId);
+        this.linked.delete(payload.fromUserId);
+        this.rtc?.removePeer(payload.fromUserId);
+        store.setPeerLinked(payload.fromUserId, false);
+        store.removeRemoteStream(payload.fromUserId);
+        void this.incoming.get(payload.fromUserId)?.abort();
+        this.incoming.delete(payload.fromUserId);
       });
 
-      socket.on('chat', (m: ServerChatMessage) => {
-        const state = useStore.getState();
-        const message: ChatMessage = {
-          id: m.id,
-          senderId: m.senderId,
-          username: m.username,
-          text: m.text,
-          ts: m.ts,
-          mine: m.senderId === state.self?.id,
-        };
-        state.addMessage(message);
+      socket.on('signal:ice', (payload: { fromUserId: string; candidate: RTCIceCandidateInit }) => {
+        void this.rtc?.handleIce(payload.fromUserId, payload.candidate);
       });
 
-      socket.on('signal', ({ from, data }: { from: string; data: never }) => {
-        this.rtc?.handleSignal(from, data);
-      });
+      // Safety timeout if room:joined never arrives.
+      setTimeout(() => {
+        if (!settled) fail('Timed out waiting for room join.');
+      }, 15_000);
     });
   }
 
-  private setupRtc(selfId: string) {
+  private membersToPeers(members: RoomMember[], selfId: string): Peer[] {
+    return members
+      .filter((m) => m.userId !== selfId)
+      .map((m) => ({ id: m.userId, username: m.name }));
+  }
+
+  /**
+   * hand-off-server allows one ringing/active call per user. We keep a single
+   * P2P data link (needed for chat/files) with one peer at a time. The lower
+   * userId is the deterministic initiator to avoid glare.
+   */
+  private reconcileLinks(members: RoomMember[]) {
+    const selfId = this.selfId;
+    if (!selfId || !this.rtc) return;
+
+    const others = members.filter((m) => m.userId !== selfId);
+    if (this.linked.size > 0 || this.linking.size > 0) return;
+
+    // Prefer a single peer: first other member by stable userId order.
+    const target = [...others].sort((a, b) => a.userId.localeCompare(b.userId))[0];
+    if (!target) return;
+
+    if (selfId < target.userId) {
+      void this.beginLink(target.userId);
+    }
+  }
+
+  private async beginLink(peerId: string) {
+    if (!this.rtc || this.linked.has(peerId) || this.linking.has(peerId)) return;
+    if (this.linked.size > 0 || this.linking.size > 0) return;
+    this.linking.add(peerId);
+    try {
+      await this.rtc.invitePeer(peerId);
+    } catch (err) {
+      this.linking.delete(peerId);
+      console.error('[session] invite failed', err);
+    }
+  }
+
+  private async onIncoming(fromUserId: string, signal: RTCSessionDescriptionInit) {
+    if (!this.rtc || !this.selfId) return;
+
+    // Busy with someone else — reject.
+    const busyWithOther =
+      [...this.linked, ...this.linking].some((id) => id !== fromUserId);
+    if (busyWithOther) {
+      this.socket?.emit('call:reject', { toUserId: fromUserId });
+      return;
+    }
+
+    this.linking.add(fromUserId);
+    try {
+      await this.rtc.handleIncoming(fromUserId, signal);
+      this.linked.add(fromUserId);
+      this.linking.delete(fromUserId);
+      useStore.getState().setPeerLinked(fromUserId, true);
+    } catch (err) {
+      this.linking.delete(fromUserId);
+      console.error('[session] accept failed', err);
+      this.socket?.emit('call:reject', { toUserId: fromUserId });
+    }
+  }
+
+  private setupRtc(selfId: string, turnServers?: RTCIceServer[]) {
+    const iceServers: RTCIceServer[] = [
+      { urls: ['stun:stun.l.google.com:19302', 'stun:stun1.l.google.com:19302'] },
+      ...(turnServers ?? []),
+    ];
+
     this.rtc = new RTCManager({
       selfId,
-      sendSignal: (to, data) => this.socket?.emit('signal', { to, data }),
+      iceServers,
+      signaling: {
+        invite: (toUserId, signal) => this.socket?.emit('call:invite', { toUserId, signal }),
+        accept: (toUserId, signal) => this.socket?.emit('call:accept', { toUserId, signal }),
+        reject: (toUserId) => this.socket?.emit('call:reject', { toUserId }),
+        end: (toUserId) => this.socket?.emit('call:end', { toUserId }),
+        ice: (toUserId, candidate) => this.socket?.emit('signal:ice', { toUserId, candidate }),
+      },
       onRemoteStream: (peerId, stream) => useStore.getState().setRemoteStream(peerId, stream),
       onRemoteStreamEnded: (peerId) => useStore.getState().removeRemoteStream(peerId),
-      onData: (peerId, data) => this.handleData(peerId, data),
+      onData: (peerId, data) => {
+        void this.handleData(peerId, data);
+      },
+      onDataChannelOpen: (peerId) => useStore.getState().setPeerLinked(peerId, true),
+      onDataChannelClose: (peerId) => useStore.getState().setPeerLinked(peerId, false),
     });
   }
 
-  private handleData(peerId: string, data: string | ArrayBuffer) {
+  private async handleData(peerId: string, data: string | ArrayBuffer) {
     const store = useStore.getState();
+
     if (typeof data === 'string') {
-      const msg = JSON.parse(data) as DataChannelControl;
+      let msg: DataChannelMessage;
+      try {
+        msg = JSON.parse(data) as DataChannelMessage;
+      } catch {
+        return;
+      }
+
+      if (msg.kind === 'chat') {
+        const message: ChatMessage = {
+          id: msg.id,
+          senderId: peerId,
+          username: store.peerName(peerId),
+          text: msg.text,
+          ts: msg.ts,
+          mine: false,
+        };
+        store.addMessage(message);
+        return;
+      }
+
       if (msg.kind === 'file-meta') {
-        this.incoming.set(peerId, new Reassembler(msg));
+        const reassembler = await StreamingReassembler.create(msg);
+        this.incoming.set(peerId, reassembler);
         const file: SharedFile = {
           id: msg.id,
           name: msg.name,
@@ -141,33 +313,74 @@ class Session {
           done: false,
         };
         store.upsertFile(file);
-      } else if (msg.kind === 'file-end') {
+        return;
+      }
+
+      if (msg.kind === 'file-end') {
         const reassembler = this.incoming.get(peerId);
-        if (reassembler) {
-          const url = URL.createObjectURL(reassembler.toBlob());
+        if (!reassembler) return;
+        try {
+          const blob = await reassembler.finalize();
+          const url = URL.createObjectURL(blob);
           store.patchFile(msg.id, { progress: 1, done: true, url });
-          this.incoming.delete(peerId);
+        } catch (err) {
+          store.patchFile(msg.id, {
+            done: true,
+            error: err instanceof Error ? err.message : 'Failed to assemble file',
+          });
         }
+        this.incoming.delete(peerId);
+        return;
+      }
+
+      if (msg.kind === 'file-abort') {
+        const reassembler = this.incoming.get(peerId);
+        await reassembler?.abort();
+        this.incoming.delete(peerId);
+        store.patchFile(msg.id, {
+          done: true,
+          error: msg.reason || 'Transfer aborted',
+        });
       }
       return;
     }
 
     const reassembler = this.incoming.get(peerId);
     if (reassembler) {
-      reassembler.push(data);
+      await reassembler.push(data);
       store.patchFile(reassembler.meta.id, { progress: reassembler.progress });
     }
   }
 
   sendChat(text: string) {
     const clean = text.trim();
-    if (!clean) return;
-    this.socket?.emit('chat', { text: clean });
+    if (!clean || !this.rtc) return;
+
+    const store = useStore.getState();
+    const id = makeFileId();
+    const ts = Date.now();
+    const message: ChatMessage = {
+      id,
+      senderId: store.self?.id ?? 'me',
+      username: store.self?.username ?? 'Me',
+      text: clean,
+      ts,
+      mine: true,
+    };
+    store.addMessage(message);
+
+    if (!this.rtc.hasOpenChannels()) {
+      store.setError('Waiting for a peer data link before chat can be delivered…');
+      return;
+    }
+
+    const payload: DataChannelMessage = { kind: 'chat', id, text: clean, ts };
+    this.rtc.broadcast(JSON.stringify(payload));
   }
 
   async shareFiles(files: FileList | File[]) {
     if (!this.rtc || !this.rtc.hasOpenChannels()) {
-      throw new Error('No connected peers yet — wait for someone to join the room.');
+      throw new Error('No connected peers yet — wait for the peer data link to open.');
     }
     const store = useStore.getState();
     for (const file of Array.from(files)) {
@@ -184,13 +397,24 @@ class Session {
         done: false,
       };
       store.upsertFile(record);
-      await sendFile(this.rtc, id, file, (progress) =>
-        store.patchFile(id, { progress, done: progress >= 1 }),
-      );
+      try {
+        await sendFile(this.rtc, id, file, (progress) =>
+          store.patchFile(id, { progress, done: progress >= 1 }),
+        );
+      } catch (err) {
+        store.patchFile(id, {
+          done: true,
+          error: err instanceof Error ? err.message : 'Transfer failed',
+        });
+        throw err;
+      }
     }
   }
 
   async startCall(withVideo: boolean) {
+    if (!this.rtc?.hasOpenChannels()) {
+      throw new Error('Connect to a peer before starting a call.');
+    }
     const store = useStore.getState();
     const stream = await navigator.mediaDevices.getUserMedia({
       audio: true,
@@ -200,12 +424,12 @@ class Session {
     store.setMic(true);
     store.setCam(withVideo);
     store.setInCall(true);
-    this.rtc?.setLocalStream(stream);
+    await this.rtc.setLocalStream(stream);
   }
 
-  leaveCall() {
+  async leaveCall() {
     const store = useStore.getState();
-    this.rtc?.stopLocalStream();
+    await this.rtc?.stopLocalStream();
     store.setLocalStream(null);
     store.setInCall(false);
     for (const id of Object.keys(store.remoteStreams)) store.removeRemoteStream(id);
@@ -216,7 +440,9 @@ class Session {
     const stream = store.localStream;
     if (!stream) return;
     const next = !store.micEnabled;
-    stream.getAudioTracks().forEach((t) => (t.enabled = next));
+    stream.getAudioTracks().forEach((t) => {
+      t.enabled = next;
+    });
     store.setMic(next);
   }
 
@@ -225,14 +451,20 @@ class Session {
     const stream = store.localStream;
     if (!stream) return;
     const next = !store.camEnabled;
-    stream.getVideoTracks().forEach((t) => (t.enabled = next));
+    stream.getVideoTracks().forEach((t) => {
+      t.enabled = next;
+    });
     store.setCam(next);
   }
 
   leaveRoom() {
-    this.leaveCall();
+    void this.leaveCall();
     this.disposeConnections();
     useStore.getState().resetRoom();
+  }
+
+  hasDataLink(): boolean {
+    return Boolean(this.rtc?.hasOpenChannels());
   }
 }
 

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -1,4 +1,5 @@
 export interface Peer {
+  /** Stable user id from the room JWT (`sub`), used for signaling targets. */
   id: string;
   username: string;
 }
@@ -27,11 +28,24 @@ export interface SharedFile {
   /** 0..1 transfer progress. */
   progress: number;
   done: boolean;
+  error?: string;
   /** Object URL, available once an incoming file is fully received. */
   url?: string;
 }
 
-/** Control messages exchanged over the WebRTC data channel. */
-export type DataChannelControl =
+/** Control / app messages exchanged over the WebRTC data channel (never Socket.IO). */
+export type DataChannelMessage =
   | { kind: 'file-meta'; id: string; name: string; size: number; mime: string }
-  | { kind: 'file-end'; id: string };
+  | { kind: 'file-end'; id: string }
+  | { kind: 'file-abort'; id: string; reason?: string }
+  | { kind: 'chat'; id: string; text: string; ts: number };
+
+/** @deprecated Use DataChannelMessage */
+export type DataChannelControl = DataChannelMessage;
+
+export interface RoomMember {
+  socketId: string;
+  userId: string;
+  name: string;
+  role?: string;
+}

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -23,6 +23,7 @@ export default function Room() {
   const error = useStore((s) => s.error);
   const self = useStore((s) => s.self);
   const peers = useStore((s) => s.peers);
+  const linkedPeers = useStore((s) => s.linkedPeers);
   const inCall = useStore((s) => s.inCall);
 
   const [tab, setTab] = useState<Tab>('chat');
@@ -100,9 +101,10 @@ export default function Room() {
           <ul className="sidebar__people">
             {participants.map((p) => (
               <li key={p.id}>
-                <span className="dot" />
+                <span className={`dot ${!p.me && linkedPeers[p.id] ? 'dot--linked' : ''}`} />
                 {p.username}
                 {p.me && <span className="tag">you</span>}
+                {!p.me && linkedPeers[p.id] && <span className="tag">linked</span>}
               </li>
             ))}
           </ul>
@@ -110,6 +112,12 @@ export default function Room() {
             <p className="sidebar__hint">
               You’re the only one here. Share the invite link or open a second
               browser tab to connect a peer.
+            </p>
+          )}
+          {peers.length > 1 && (
+            <p className="sidebar__hint">
+              Signaling supports one active peer link at a time. Chat, files, and
+              calls use the linked peer.
             </p>
           )}
         </aside>

--- a/client/src/store/useStore.ts
+++ b/client/src/store/useStore.ts
@@ -9,6 +9,8 @@ interface StoreState {
   error: string | null;
 
   peers: Peer[];
+  /** userIds with an open (or accepted) WebRTC data link */
+  linkedPeers: Record<string, boolean>;
   messages: ChatMessage[];
   files: SharedFile[];
 
@@ -24,6 +26,7 @@ interface StoreState {
   setSession: (self: Peer, roomId: string) => void;
 
   setPeers: (peers: Peer[]) => void;
+  setPeerLinked: (id: string, linked: boolean) => void;
   addPeer: (peer: Peer) => void;
   removePeer: (id: string) => void;
   peerName: (id: string) => string;
@@ -51,6 +54,7 @@ export const useStore = create<StoreState>((set, get) => ({
   error: null,
 
   peers: [],
+  linkedPeers: {},
   messages: [],
   files: [],
 
@@ -66,6 +70,8 @@ export const useStore = create<StoreState>((set, get) => ({
   setSession: (self, roomId) => set({ self, roomId }),
 
   setPeers: (peers) => set({ peers }),
+  setPeerLinked: (id, linked) =>
+    set((s) => ({ linkedPeers: { ...s.linkedPeers, [id]: linked } })),
   addPeer: (peer) =>
     set((s) =>
       s.peers.some((p) => p.id === peer.id)
@@ -76,7 +82,9 @@ export const useStore = create<StoreState>((set, get) => ({
     set((s) => {
       const remoteStreams = { ...s.remoteStreams };
       delete remoteStreams[id];
-      return { peers: s.peers.filter((p) => p.id !== id), remoteStreams };
+      const linkedPeers = { ...s.linkedPeers };
+      delete linkedPeers[id];
+      return { peers: s.peers.filter((p) => p.id !== id), remoteStreams, linkedPeers };
     }),
   peerName: (id) => {
     if (id === get().self?.id || id === 'me') return get().self?.username ?? 'Me';
@@ -119,6 +127,7 @@ export const useStore = create<StoreState>((set, get) => ({
       connected: false,
       error: null,
       peers: [],
+      linkedPeers: {},
       messages: [],
       files: [],
       inCall: false,

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -150,6 +150,7 @@ input:focus, textarea:focus {
   font-size: 14px;
 }
 .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--ok); box-shadow: 0 0 8px var(--ok); }
+.dot--linked { background: var(--accent, #3b82f6); box-shadow: 0 0 8px var(--accent, #3b82f6); }
 .tag { margin-left: auto; font-size: 11px; color: var(--text-dim); background: var(--bg-elev-2); padding: 2px 8px; border-radius: 999px; }
 .sidebar__hint { color: var(--text-dim); font-size: 12.5px; line-height: 1.5; }
 

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,6 +1,11 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  /** Optional absolute URL for the session BFF (`POST /api/session`). */
+  readonly VITE_API_URL?: string;
+  /** Optional absolute URL for hand-off-server Socket.IO + TURN HTTP API. */
+  readonly VITE_SIGNALING_URL?: string;
+  /** @deprecated Prefer VITE_SIGNALING_URL */
   readonly VITE_SERVER_URL?: string;
 }
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,18 +1,22 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
-// The signaling server runs separately in dev (default :4000). We proxy
-// socket.io traffic through Vite so the client can talk to it same-origin
-// (no CORS) and connect with a plain `io()` call.
-const SERVER_PORT = process.env.SERVER_PORT || '4000';
+// Session BFF (token minting) defaults to :4000.
+// hand-off-server (Socket.IO signaling) defaults to :8989.
+const BFF_PORT = process.env.BFF_PORT || process.env.SERVER_PORT || '4000';
+const SIGNALING_PORT = process.env.SIGNALING_PORT || '8989';
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
+      '/api': {
+        target: `http://localhost:${BFF_PORT}`,
+        changeOrigin: true,
+      },
       '/socket.io': {
-        target: `http://localhost:${SERVER_PORT}`,
+        target: `http://localhost:${SIGNALING_PORT}`,
         ws: true,
         changeOrigin: true,
       },

--- a/docs/BACKEND_GAPS.md
+++ b/docs/BACKEND_GAPS.md
@@ -1,0 +1,52 @@
+# Backend discussion notes (hand-off-server)
+
+Frontend work in this PR targets [hand-off-server PR #10](https://github.com/gravy17/hand-off-server/pull/10)
+**without** changing that repo. These are the gaps that still limit feature parity
+with the old mesh model. Discuss before implementing server-side.
+
+## What works today (no server changes)
+
+| Feature | Approach |
+| --- | --- |
+| Auth / rooms / presence | JWT handshake + `room:joined` / `presence:update` |
+| 1:1 WebRTC link | `call:invite` → `call:accept` + `signal:ice` |
+| Chat | WebRTC data channel only (no Socket.IO chat) |
+| File transfer (any size) | WebRTC data channel + SCTP backpressure; OPFS on receive |
+| A/V after link | Pre-created audio/video transceivers + `replaceTrack` |
+
+## Gaps that need server changes for full parity
+
+1. **Mesh / multi-peer data links**  
+   The call registry allows **one** ringing/active call per `userId`. A room with
+   3+ people cannot keep simultaneous P2P links to every peer. Today the client
+   auto-links to a single peer.
+
+   *Possible server change:* concurrent “data sessions” per peer pair that do not
+   consume the A/V call slot, **or** allowlisted `signal:sdp` relay without the
+   one-call-per-user lock.
+
+2. **Mid-call SDP renegotiation**  
+   Only the invite offer and accept answer carry SDP. Perfect negotiation /
+   track add/remove via new offers is impossible.
+
+   *Possible server change:* `signal:sdp` (or generic `signal`) relay while a
+   call/session is active. The client currently avoids this with `replaceTrack`.
+
+3. **Room-wide chat without a data link**  
+   Chat no longer has a Socket.IO relay. Until a WebRTC link is up, messages
+   cannot be delivered (and cannot fan out to unlinked peers).
+
+   *Possible server change:* optional room-scoped `chat` event (rate-limited,
+   size-capped), or accept chat-only over data channels as the product rule.
+
+4. **SDP payload headroom**  
+   Default `MAX_PAYLOAD_BYTES=16384` is usually enough for a 2-m-line offer, but
+   heavy codec lists can approach the limit.
+
+   *Possible server change:* raise the default (e.g. 64 KiB) or document a
+   recommended floor for browser SDPs.
+
+## Preference
+
+File bytes and chat content should stay off Socket.IO. Any server additions
+should be signaling/control only.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,24 @@
 # Netlify build configuration.
 #
-# Netlify can only host the static client. The Socket.IO signaling server
-# (server/) must be deployed separately (any Node host); point the client at it
-# by setting the VITE_SERVER_URL environment variable in the Netlify UI.
+# Netlify hosts the static client + a session-minting function. Socket.IO
+# signaling lives on hand-off-server — set VITE_SIGNALING_URL (and
+# ROOM_TOKEN_SECRET for the function) in the Netlify UI.
 
 [build]
   command = "npm run build"
   publish = "client/dist"
+  functions = "netlify/functions"
 
 [build.environment]
   # npm workspaces (the --workspace flag) require npm 7+, i.e. Node 15+.
   NODE_VERSION = "20"
+
+# Session minting BFF equivalent for Netlify.
+[[redirects]]
+  from = "/api/session"
+  to = "/.netlify/functions/session"
+  status = 200
+  force = true
 
 # Single-page app: let React Router handle client-side routes.
 [[redirects]]

--- a/netlify/functions/session.mjs
+++ b/netlify/functions/session.mjs
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+
+const ROOM_TOKEN_SECRET = process.env.ROOM_TOKEN_SECRET || '';
+const TOKEN_TTL_SECONDS = Number(process.env.TOKEN_TTL_SECONDS) || 900;
+const SIGNALING_URL = process.env.SIGNALING_URL || process.env.VITE_SIGNALING_URL || '';
+
+const corsHeaders = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-headers': 'content-type',
+  'access-control-allow-methods': 'POST, OPTIONS',
+  'content-type': 'application/json',
+};
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: corsHeaders, body: '' };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: corsHeaders, body: JSON.stringify({ error: 'method not allowed' }) };
+  }
+
+  if (!ROOM_TOKEN_SECRET) {
+    return {
+      statusCode: 503,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'ROOM_TOKEN_SECRET is not configured' }),
+    };
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'invalid JSON' }) };
+  }
+
+  const roomId = String(body.roomId || '').trim();
+  const username = String(body.username || '').trim().slice(0, 40) || 'Anonymous';
+  const userId = String(body.userId || '').trim() || randomUUID();
+
+  if (!roomId) {
+    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'roomId is required' }) };
+  }
+
+  try {
+    const token = jwt.sign(
+      { sub: userId, name: username, roomId, role: 'member' },
+      ROOM_TOKEN_SECRET,
+      { algorithm: 'HS256', expiresIn: TOKEN_TTL_SECONDS },
+    );
+
+    return {
+      statusCode: 200,
+      headers: corsHeaders,
+      body: JSON.stringify({
+        token,
+        userId,
+        username,
+        roomId,
+        expiresIn: TOKEN_TTL_SECONDS,
+        signalingUrl: SIGNALING_URL || undefined,
+      }),
+    };
+  } catch (err) {
+    console.error('session mint failed', err);
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'failed to mint session' }),
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "client",
         "server"
       ],
+      "dependencies": {
+        "jsonwebtoken": "^9.0.2"
+      },
       "devDependencies": {
         "concurrently": "^9.1.0"
       }
@@ -1412,15 +1415,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1439,7 +1433,10 @@
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1470,15 +1467,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2019,15 +2007,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "license": "MIT",
-      "engines": {
-        "node": "^4.5.0 || >= 5.9"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.3",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
@@ -2124,6 +2103,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2477,6 +2462,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2504,27 +2498,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/engine.io": {
-      "version": "6.6.9",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
-      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "@types/ws": "^8.5.12",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.7.2",
-        "cors": "~2.8.5",
-        "debug": "~4.4.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.21.0"
-      },
-      "engines": {
-        "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
@@ -3415,6 +3388,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3455,11 +3483,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -4266,34 +4336,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/socket.io": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
-      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "base64id": "~2.0.0",
-        "cors": "~2.8.5",
-        "debug": "~4.4.1",
-        "engine.io": "~6.6.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/socket.io-adapter": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
-      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~4.4.1",
-        "ws": "~8.21.0"
-      }
-    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -4580,7 +4622,10 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -4983,7 +5028,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.1",
-        "socket.io": "^4.8.1"
+        "jsonwebtoken": "^9.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,19 @@
     "server"
   ],
   "scripts": {
-    "dev": "concurrently -n server,client -c magenta,cyan \"npm:dev:server\" \"npm:dev:client\"",
-    "dev:server": "npm --workspace @hand-off/server run dev",
+    "dev": "concurrently -n bff,client -c magenta,cyan \"npm:dev:bff\" \"npm:dev:client\"",
+    "dev:all": "concurrently -n signaling,bff,client -c yellow,magenta,cyan \"npm:dev:signaling\" \"npm:dev:bff\" \"npm:dev:client\"",
+    "dev:signaling": "npm --prefix ../hand-off-server run dev",
+    "dev:bff": "npm --workspace @hand-off/server run dev",
+    "dev:server": "npm run dev:bff",
     "dev:client": "npm --workspace @hand-off/client run dev",
     "build": "npm --workspace @hand-off/client run build",
     "start": "npm --workspace @hand-off/server run start",
     "lint": "npm --workspace @hand-off/client run lint",
     "test": "npm --workspace @hand-off/client run test"
+  },
+  "dependencies": {
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "concurrently": "^9.1.0"

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "type": "module",
-  "description": "HandOff signaling server: rooms, presence, chat relay, and WebRTC signaling.",
+  "description": "HandOff session BFF: mints room JWTs for hand-off-server and serves the built client.",
   "main": "src/index.js",
   "scripts": {
     "dev": "node --watch src/index.js",
@@ -12,6 +12,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.21.1",
-    "socket.io": "^4.8.1"
+    "jsonwebtoken": "^9.0.2"
   }
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,106 +2,94 @@ import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 
 import express from 'express';
 import cors from 'cors';
-import { Server } from 'socket.io';
+import jwt from 'jsonwebtoken';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const PORT = Number(process.env.PORT) || 4000;
 const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || '*';
+// Must match hand-off-server's ROOM_TOKEN_SECRET (dev default mirrors that repo).
+const ROOM_TOKEN_SECRET =
+  process.env.ROOM_TOKEN_SECRET || 'dev-room-token-secret-change-me';
+const TOKEN_TTL_SECONDS = Number(process.env.TOKEN_TTL_SECONDS) || 900;
+const SIGNALING_URL = process.env.SIGNALING_URL || 'http://localhost:8989';
 
 const app = express();
+app.disable('x-powered-by');
 app.use(cors({ origin: CLIENT_ORIGIN }));
+app.use(express.json({ limit: '16kb' }));
 
 app.get('/health', (_req, res) => {
-  res.json({ ok: true, service: 'hand-off-server' });
+  res.json({
+    ok: true,
+    service: 'hand-off-bff',
+    signalingUrl: SIGNALING_URL,
+  });
 });
 
-// In production, serve the built client (single-service deployment).
+/**
+ * Mint a short-lived room JWT the browser can present to hand-off-server.
+ * Identity (userId) is created here so the secret never ships to the client.
+ *
+ * POST /api/session
+ * body: { roomId, username, userId? }
+ */
+app.post('/api/session', (req, res) => {
+  const roomId = String(req.body?.roomId || '').trim();
+  const username = String(req.body?.username || '').trim().slice(0, 40) || 'Anonymous';
+  const userId = String(req.body?.userId || '').trim() || randomUUID();
+
+  if (!roomId) {
+    res.status(400).json({ error: 'roomId is required' });
+    return;
+  }
+  if (roomId.length > 128) {
+    res.status(400).json({ error: 'roomId is too long' });
+    return;
+  }
+
+  try {
+    const token = jwt.sign(
+      {
+        sub: userId,
+        name: username,
+        roomId,
+        role: 'member',
+      },
+      ROOM_TOKEN_SECRET,
+      { algorithm: 'HS256', expiresIn: TOKEN_TTL_SECONDS },
+    );
+
+    res.json({
+      token,
+      userId,
+      username,
+      roomId,
+      expiresIn: TOKEN_TTL_SECONDS,
+      signalingUrl: SIGNALING_URL,
+    });
+  } catch (err) {
+    console.error('[hand-off-bff] failed to mint session', err);
+    res.status(500).json({ error: 'failed to mint session' });
+  }
+});
+
+// In production, serve the built client (single-service deployment of the UI + BFF).
 const clientDist = join(__dirname, '..', '..', 'client', 'dist');
 if (existsSync(clientDist)) {
   app.use(express.static(clientDist));
-  app.get('*', (_req, res) => {
+  app.get('*', (req, res, next) => {
+    if (req.path.startsWith('/api')) return next();
     res.sendFile(join(clientDist, 'index.html'));
   });
 }
 
 const httpServer = createServer(app);
-const io = new Server(httpServer, {
-  cors: { origin: CLIENT_ORIGIN, methods: ['GET', 'POST'] },
-});
-
-/**
- * Return the list of other members of a room as `{ id, username }`.
- */
-function roomMembers(roomId, exceptId) {
-  const room = io.sockets.adapter.rooms.get(roomId);
-  if (!room) return [];
-  const members = [];
-  for (const socketId of room) {
-    if (socketId === exceptId) continue;
-    const s = io.sockets.sockets.get(socketId);
-    if (s) members.push({ id: socketId, username: s.data.username });
-  }
-  return members;
-}
-
-io.on('connection', (socket) => {
-  socket.on('join', ({ roomId, username }, ack) => {
-    const cleanRoom = String(roomId || '').trim();
-    const cleanName = String(username || '').trim().slice(0, 40) || 'Anonymous';
-    if (!cleanRoom) {
-      if (typeof ack === 'function') ack({ error: 'A room name is required.' });
-      return;
-    }
-
-    // Leave any previous room first.
-    if (socket.data.roomId) {
-      socket.leave(socket.data.roomId);
-      socket.to(socket.data.roomId).emit('peer-left', { id: socket.id });
-    }
-
-    socket.data.username = cleanName;
-    socket.data.roomId = cleanRoom;
-    socket.join(cleanRoom);
-
-    const peers = roomMembers(cleanRoom, socket.id);
-    if (typeof ack === 'function') {
-      ack({ selfId: socket.id, roomId: cleanRoom, username: cleanName, peers });
-    }
-    socket.to(cleanRoom).emit('peer-joined', { id: socket.id, username: cleanName });
-  });
-
-  socket.on('chat', ({ text }) => {
-    const roomId = socket.data.roomId;
-    if (!roomId) return;
-    const clean = String(text ?? '').slice(0, 4000);
-    if (!clean) return;
-    io.to(roomId).emit('chat', {
-      id: `${socket.id}-${Date.now()}`,
-      senderId: socket.id,
-      username: socket.data.username,
-      text: clean,
-      ts: Date.now(),
-    });
-  });
-
-  // Relay WebRTC signaling messages to a specific peer in the room.
-  socket.on('signal', ({ to, data }) => {
-    if (!to) return;
-    io.to(to).emit('signal', { from: socket.id, data });
-  });
-
-  socket.on('disconnect', () => {
-    const roomId = socket.data.roomId;
-    if (roomId) {
-      socket.to(roomId).emit('peer-left', { id: socket.id });
-    }
-  });
-});
-
 httpServer.listen(PORT, () => {
-  console.log(`[hand-off] signaling server listening on http://localhost:${PORT}`);
+  console.log(`[hand-off] session BFF listening on http://localhost:${PORT}`);
+  console.log(`[hand-off] minting tokens for signaling at ${SIGNALING_URL}`);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the HandOff frontend with [hand-off-server PR #10](https://github.com/gravy17/hand-off-server/pull/10) and keeps chat / calls / file sharing working without putting file bytes (or chat) on Socket.IO.

### Harmonization
- Repurposed `server/` into a **session BFF** that mints room JWTs (`POST /api/session`) instead of running legacy Socket.IO signaling
- Client connects to `hand-off-server` with `auth.token`, handles `room:joined` / `presence:update`, and uses `call:invite` → `call:accept` + `signal:ice`
- Auto-establishes a single peer data link (server allows one active call per user)
- Chat moved onto the WebRTC data channel
- A/V uses pre-created transceivers + `replaceTrack` (avoids mid-call SDP, which the new API does not support)
- Netlify function mirrors `/api/session` for static hosting
- Vite proxies `/api` → BFF `:4000` and `/socket.io` → signaling `:8989`

### Any-size WebRTC file streaming
- Sender streams `File.slice` chunks with SCTP backpressure via `bufferedamountlow`
- Receiver uses Origin Private File System when available so multi‑GB transfers are not held entirely in RAM
- Abort signaling over the data channel; no Socket.IO involvement in the data plane

### Backend discussion (no server-repo changes in this PR)
See `docs/BACKEND_GAPS.md`. Notable limits if we want full old-mesh parity later:
1. Multi-peer simultaneous data links (one-call-per-user)
2. Mid-call SDP renegotiation (`signal:sdp`)
3. Optional room chat relay before a data link exists
4. Possibly higher default `MAX_PAYLOAD_BYTES` for heavy SDPs

**Please discuss those before any hand-off-server changes.** This PR stays frontend-only.

## Test plan
- [x] `npm test` / `npm run lint` / `npm run build`
- [x] BFF `POST /api/session` mints JWT accepted by hand-off-server
- [x] Two Socket.IO clients: join → invite → accept → ICE smoke against local signaling
- [ ] Manual UI: two tabs, chat + large file + A/V call

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83841aa7-ac08-4506-9f97-645c12c783ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83841aa7-ac08-4506-9f97-645c12c783ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

