### PR TITLE
Deploy session BFF + client dist on Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Session BFF (this repo's server/)
+# Session BFF (this repo's server/ — local Node)
 PORT=4000
 CLIENT_ORIGIN=http://localhost:5173
 # Must match hand-off-server ROOM_TOKEN_SECRET
@@ -9,3 +9,14 @@ SIGNALING_URL=http://localhost:8989
 # Vite client (optional overrides — leave unset to use same-origin proxies)
 # VITE_API_URL=
 # VITE_SIGNALING_URL=http://localhost:8989
+
+# Vercel (Project → Settings → Environment Variables)
+# Build-time:
+#   VITE_SIGNALING_URL=https://your-hand-off-server.onrender.com
+# Runtime (Serverless /api/session):
+#   ROOM_TOKEN_SECRET=<same as hand-off-server>
+#   SIGNALING_URL=https://your-hand-off-server.onrender.com
+#   TOKEN_TTL_SECONDS=900
+#
+# On hand-off-server, set:
+#   ALLOWED_ORIGINS=https://your-app.vercel.app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ HandOff is an npm-workspaces monorepo for a peer-to-peer chat / audio-video call
 ### Services
 - `@hand-off/client` (`client/`) — React 18 + TypeScript + Vite dev server on **:5173**.
 - `@hand-off/server` (`server/`) — Express session BFF on **:4000** (mints room JWTs; no Socket.IO).
+- `api/session.js` — same mint endpoint as a Vercel serverless function (`vercel.json`).
 - `hand-off-server` (sibling repo) — authenticated signaling on **:8989**.
 
 Run BFF + client with `npm run dev`. When `../hand-off-server` exists,

--- a/README.md
+++ b/README.md
@@ -69,10 +69,43 @@ Open http://localhost:5173, pick a display name and room, then open a second tab
 
 | Variable | Where | Purpose |
 | --- | --- | --- |
-| `ROOM_TOKEN_SECRET` | BFF + hand-off-server | Shared HS256 secret for room JWTs |
-| `SIGNALING_URL` | BFF | Advertised signaling base URL in `/api/session` |
+| `ROOM_TOKEN_SECRET` | BFF / Vercel / Netlify + hand-off-server | Shared HS256 secret for room JWTs |
+| `SIGNALING_URL` | BFF / serverless | Advertised signaling base URL in `/api/session` |
 | `VITE_SIGNALING_URL` | client build | Absolute Socket.IO URL (production) |
 | `VITE_API_URL` | client build | Absolute BFF URL when not same-origin |
+
+## Deploy on Vercel
+
+Vercel serves `client/dist` as static files and runs the session BFF as a
+serverless function at `/api/session` (`api/session.js`). Signaling still lives
+on `hand-off-server`.
+
+1. Deploy / run `hand-off-server` somewhere (Render, etc.) with:
+   - `ROOM_TOKEN_SECRET=<strong-secret>`
+   - `ALLOWED_ORIGINS=https://your-app.vercel.app`
+   - `NODE_ENV=production`
+2. Import this GitHub repo into [Vercel](https://vercel.com/new).
+3. In the Vercel project settings, set:
+
+| Environment | Variable | Value |
+| --- | --- | --- |
+| Production (Build) | `VITE_SIGNALING_URL` | `https://your-hand-off-server.example.com` |
+| Production (Runtime) | `ROOM_TOKEN_SECRET` | same secret as hand-off-server |
+| Production (Runtime) | `SIGNALING_URL` | same URL as `VITE_SIGNALING_URL` |
+
+4. Framework Preset: **Other** (or leave unset — `vercel.json` sets it).
+5. Deploy. Smoke-check:
+   - `GET https://your-app.vercel.app/` → SPA
+   - `POST https://your-app.vercel.app/api/session` with
+     `{"roomId":"demo","username":"Ada"}` → JWT JSON
+6. Open two browser tabs on the deployed site and join the same room.
+
+CLI alternative:
+
+```bash
+npx vercel          # preview
+npx vercel --prod   # production
+```
 
 ## License
 

--- a/api/session.js
+++ b/api/session.js
@@ -1,0 +1,26 @@
+/**
+ * Vercel serverless adapter for the session BFF.
+ * Same contract as Express POST /api/session and the Netlify function.
+ */
+import { mintSession } from '../server/src/mintSession.js';
+
+export default function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'content-type');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'method not allowed' });
+    return;
+  }
+
+  const result = mintSession(req.body || {}, {
+    allowDevSecret: false,
+  });
+  res.status(result.status).json(result.body);
+}

--- a/netlify/functions/session.mjs
+++ b/netlify/functions/session.mjs
@@ -1,9 +1,4 @@
-import { randomUUID } from 'node:crypto';
-import jwt from 'jsonwebtoken';
-
-const ROOM_TOKEN_SECRET = process.env.ROOM_TOKEN_SECRET || '';
-const TOKEN_TTL_SECONDS = Number(process.env.TOKEN_TTL_SECONDS) || 900;
-const SIGNALING_URL = process.env.SIGNALING_URL || process.env.VITE_SIGNALING_URL || '';
+import { mintSession } from '../../server/src/mintSession.js';
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -18,57 +13,28 @@ export async function handler(event) {
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers: corsHeaders, body: JSON.stringify({ error: 'method not allowed' }) };
-  }
-
-  if (!ROOM_TOKEN_SECRET) {
     return {
-      statusCode: 503,
+      statusCode: 405,
       headers: corsHeaders,
-      body: JSON.stringify({ error: 'ROOM_TOKEN_SECRET is not configured' }),
+      body: JSON.stringify({ error: 'method not allowed' }),
     };
   }
 
-  let body;
+  let body = {};
   try {
     body = JSON.parse(event.body || '{}');
   } catch {
-    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'invalid JSON' }) };
-  }
-
-  const roomId = String(body.roomId || '').trim();
-  const username = String(body.username || '').trim().slice(0, 40) || 'Anonymous';
-  const userId = String(body.userId || '').trim() || randomUUID();
-
-  if (!roomId) {
-    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'roomId is required' }) };
-  }
-
-  try {
-    const token = jwt.sign(
-      { sub: userId, name: username, roomId, role: 'member' },
-      ROOM_TOKEN_SECRET,
-      { algorithm: 'HS256', expiresIn: TOKEN_TTL_SECONDS },
-    );
-
     return {
-      statusCode: 200,
+      statusCode: 400,
       headers: corsHeaders,
-      body: JSON.stringify({
-        token,
-        userId,
-        username,
-        roomId,
-        expiresIn: TOKEN_TTL_SECONDS,
-        signalingUrl: SIGNALING_URL || undefined,
-      }),
-    };
-  } catch (err) {
-    console.error('session mint failed', err);
-    return {
-      statusCode: 500,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: 'failed to mint session' }),
+      body: JSON.stringify({ error: 'invalid JSON' }),
     };
   }
+
+  const result = mintSession(body, { allowDevSecret: false });
+  return {
+    statusCode: result.status,
+    headers: corsHeaders,
+    body: JSON.stringify(result.body),
+  };
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hand-off",
   "version": "2.0.0",
   "private": true,
+  "type": "module",
   "description": "HandOff — a peer-to-peer web app for real-time chat, audio/video calls, and file sharing.",
   "license": "MIT",
   "workspaces": [

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,21 +2,18 @@ import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { randomUUID } from 'node:crypto';
 
 import express from 'express';
 import cors from 'cors';
-import jwt from 'jsonwebtoken';
+
+import { mintSession } from './mintSession.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const PORT = Number(process.env.PORT) || 4000;
 const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || '*';
-// Must match hand-off-server's ROOM_TOKEN_SECRET (dev default mirrors that repo).
-const ROOM_TOKEN_SECRET =
-  process.env.ROOM_TOKEN_SECRET || 'dev-room-token-secret-change-me';
-const TOKEN_TTL_SECONDS = Number(process.env.TOKEN_TTL_SECONDS) || 900;
 const SIGNALING_URL = process.env.SIGNALING_URL || 'http://localhost:8989';
+const isProd = process.env.NODE_ENV === 'production';
 
 const app = express();
 app.disable('x-powered-by');
@@ -33,52 +30,17 @@ app.get('/health', (_req, res) => {
 
 /**
  * Mint a short-lived room JWT the browser can present to hand-off-server.
- * Identity (userId) is created here so the secret never ships to the client.
- *
- * POST /api/session
- * body: { roomId, username, userId? }
+ * POST /api/session  body: { roomId, username, userId? }
  */
 app.post('/api/session', (req, res) => {
-  const roomId = String(req.body?.roomId || '').trim();
-  const username = String(req.body?.username || '').trim().slice(0, 40) || 'Anonymous';
-  const userId = String(req.body?.userId || '').trim() || randomUUID();
-
-  if (!roomId) {
-    res.status(400).json({ error: 'roomId is required' });
-    return;
-  }
-  if (roomId.length > 128) {
-    res.status(400).json({ error: 'roomId is too long' });
-    return;
-  }
-
-  try {
-    const token = jwt.sign(
-      {
-        sub: userId,
-        name: username,
-        roomId,
-        role: 'member',
-      },
-      ROOM_TOKEN_SECRET,
-      { algorithm: 'HS256', expiresIn: TOKEN_TTL_SECONDS },
-    );
-
-    res.json({
-      token,
-      userId,
-      username,
-      roomId,
-      expiresIn: TOKEN_TTL_SECONDS,
-      signalingUrl: SIGNALING_URL,
-    });
-  } catch (err) {
-    console.error('[hand-off-bff] failed to mint session', err);
-    res.status(500).json({ error: 'failed to mint session' });
-  }
+  const result = mintSession(req.body, {
+    signalingUrl: SIGNALING_URL,
+    allowDevSecret: !isProd,
+  });
+  res.status(result.status).json(result.body);
 });
 
-// In production, serve the built client (single-service deployment of the UI + BFF).
+// Local/Node deploys: serve the built client next to the BFF.
 const clientDist = join(__dirname, '..', '..', 'client', 'dist');
 if (existsSync(clientDist)) {
   app.use(express.static(clientDist));

--- a/server/src/mintSession.js
+++ b/server/src/mintSession.js
@@ -1,0 +1,68 @@
+import { randomUUID } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+
+/**
+ * Shared room-JWT mint used by the Express BFF and serverless adapters.
+ * @returns {{ ok: true, status: number, body: object } | { ok: false, status: number, body: { error: string } }}
+ */
+export function mintSession(
+  { roomId, username, userId } = {},
+  {
+    roomTokenSecret = process.env.ROOM_TOKEN_SECRET || '',
+    tokenTtlSeconds = Number(process.env.TOKEN_TTL_SECONDS) || 900,
+    signalingUrl = process.env.SIGNALING_URL || process.env.VITE_SIGNALING_URL || '',
+    allowDevSecret = false,
+  } = {},
+) {
+  const secret =
+    roomTokenSecret ||
+    (allowDevSecret ? 'dev-room-token-secret-change-me' : '');
+
+  if (!secret) {
+    return {
+      ok: false,
+      status: 503,
+      body: { error: 'ROOM_TOKEN_SECRET is not configured' },
+    };
+  }
+
+  const cleanRoom = String(roomId || '').trim();
+  const cleanName = String(username || '').trim().slice(0, 40) || 'Anonymous';
+  const cleanUser = String(userId || '').trim() || randomUUID();
+
+  if (!cleanRoom) {
+    return { ok: false, status: 400, body: { error: 'roomId is required' } };
+  }
+  if (cleanRoom.length > 128) {
+    return { ok: false, status: 400, body: { error: 'roomId is too long' } };
+  }
+
+  try {
+    const token = jwt.sign(
+      {
+        sub: cleanUser,
+        name: cleanName,
+        roomId: cleanRoom,
+        role: 'member',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: tokenTtlSeconds },
+    );
+
+    return {
+      ok: true,
+      status: 200,
+      body: {
+        token,
+        userId: cleanUser,
+        username: cleanName,
+        roomId: cleanRoom,
+        expiresIn: tokenTtlSeconds,
+        signalingUrl: signalingUrl || undefined,
+      },
+    };
+  } catch (err) {
+    console.error('[hand-off] failed to mint session', err);
+    return { ok: false, status: 500, body: { error: 'failed to mint session' } };
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "client/dist",
+  "installCommand": "npm install",
+  "framework": null,
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Vercel deploy path so this repo can host the built client and the session-mint BFF together:

- `client/dist` served as Vercel static output
- `api/session.js` serverless function = Express `POST /api/session`
- Shared mint logic in `server/src/mintSession.js` (Express, Vercel, Netlify)
- README deploy steps + env vars

Signaling remains on `hand-off-server` (not on Vercel).

## Env vars (Vercel project)

| When | Variable | Value |
| --- | --- | --- |
| Build | `VITE_SIGNALING_URL` | `https://your-hand-off-server…` |
| Runtime | `ROOM_TOKEN_SECRET` | same secret as hand-off-server |
| Runtime | `SIGNALING_URL` | same URL as `VITE_SIGNALING_URL` |

On hand-off-server: `ALLOWED_ORIGINS=https://your-app.vercel.app`

## Test plan
- [x] `npm test` / `npm run build`
- [ ] `npx vercel` preview deploy
- [ ] `POST /api/session` returns JWT
- [ ] Two tabs join a room against deployed signaling

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83841aa7-ac08-4506-9f97-645c12c783ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83841aa7-ac08-4506-9f97-645c12c783ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

